### PR TITLE
add asyncio to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ redis==2.10.5
 pytest-tornado==0.4.4
 prometheus_client==0.0.13
 wrapt==1.10.6
+asyncio==3.4.3


### PR DESCRIPTION
seems to be required according to error messages appearing when it is missing