### PR TITLE
Move Prefix management and authentication into the block server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Installation:
 	pip install -r requirements.txt
 	python run.py
 
+
+The server needs a postgresql database that needs to me initialized by
+
+    python manage.py initdb --psql-dsn "postgresql://username:password@localhost/dbname"

--- a/config.ini.example
+++ b/config.ini.example
@@ -5,3 +5,4 @@ redis_port=8765
 accounting_host="http://localhost:8877"
 port=8888
 api_secret="Foobar"
+psql_dsn='postgresql://postgres:postgres@localhost/qabel-block'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hiredis==0.2.0
+hiredis==0.2.0=
 glinda==0.0.3
 boto3==1.2.3
 pytest==2.8.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ prometheus_client==0.0.13
 wrapt==1.10.6
 asyncio==3.4.3
 psycopg2==2.6.1
+pytest-dbfixtures==0.13.1
+pytest-mock==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hiredis==0.2.0=
+hiredis==0.2.0
 glinda==0.0.3
 boto3==1.2.3
 pytest==2.8.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-tornado==0.4.4
 prometheus_client==0.0.13
 wrapt==1.10.6
 asyncio==3.4.3
+psycopg2==2.6.1

--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -1,0 +1,71 @@
+from blockserver import monitoring as mon
+from tornado.httpclient import AsyncHTTPClient, HTTPError
+from blockserver.server import options
+import json
+
+
+class AuthError(Exception):
+    pass
+
+
+class UserNotFound(AuthError):
+    pass
+
+
+class DummyAuth:
+
+    @staticmethod
+    async def auth(auth_header: str) -> int:
+        return 0
+
+
+class Auth:
+
+    @staticmethod
+    async def auth(auth_header: str) -> int:
+        user = CacheAuth.auth(auth_header)
+        if user is None:
+            user = await AccountingServerAuth.request(auth_header)
+        if user is None:
+            raise UserNotFound(auth_header)
+        return user
+
+
+class AccountingServerAuth:
+
+    @staticmethod
+    @mon.time(mon.WAIT_FOR_AUTH)
+    async def request(auth_header: str) -> int:
+        request_body = json.dumps({'auth': auth_header})
+        response = await AccountingServerAuth.send_request(request_body)
+        body = json.loads(response.content)
+        return body.get('user_id', None)
+
+    @staticmethod
+    async def send_request(request_body):
+        http_client = AsyncHTTPClient()
+        url = AccountingServerAuth.auth_url()
+        try:
+            return await http_client.fetch(
+                url, headers={'APISECRET': AccountingServerAuth.api_secret()},
+                body=request_body, method='POST')
+        except HTTPError as e:
+            if e.code == 404:
+                raise UserNotFound(request_body)
+            else:
+                raise AuthError(e.message)
+
+    @staticmethod
+    def api_secret():
+        return options.apisecret
+
+    @staticmethod
+    def auth_url():
+        return options.accounting_host + '/api/v0/auth/'
+
+
+class CacheAuth:
+
+    @staticmethod
+    def auth(auth_header: str) -> int:
+        pass

--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -64,7 +64,8 @@ class AccountingServerAuth:
         url = AccountingServerAuth.auth_url()
         try:
             return await http_client.fetch(
-                url, headers={'APISECRET': AccountingServerAuth.api_secret()},
+                url, headers={'APISECRET': AccountingServerAuth.api_secret(),
+                                'Content-Type': 'application/json'},
                 body=request_body, method='POST')
         except HTTPError as e:
             if e.code == 404:

--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -21,7 +21,7 @@ class DummyAuth:
         pass
 
     async def auth(self, auth_header: str) -> int:
-        return 0
+        return User(user_id=0, is_active=True)
 
 
 class Auth:

--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -48,7 +48,11 @@ class AccountingServerAuth:
     async def request(auth_header: str) -> User:
         request_body = json.dumps({'auth': auth_header})
         response = await AccountingServerAuth.send_request(request_body)
-        body = json.loads(response.body.decode('utf-8'))
+        try:
+            body = json.loads(response.body.decode('utf-8'))
+        except json.JSONDecodeError as e:
+            raise AuthError(e)
+
         try:
             return User(user_id=body.get('user_id'), is_active=body.get('active'))
         except KeyError:

--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -20,7 +20,7 @@ class DummyAuth:
     def __init__(self, cache_backend):
         pass
 
-    async def auth(cache_backend: AbstractCache, auth_header: str) -> int:
+    async def auth(self, auth_header: str) -> int:
         return 0
 
 

--- a/src/blockserver/backend/cache.py
+++ b/src/blockserver/backend/cache.py
@@ -38,18 +38,16 @@ class AbstractCache(ABC):
         size = int(size)
         return storage_object._replace(etag=etag, size=size)
 
-    def set_auth(self, authentication_token: str, prefix: str, method: str, value: bool):
-        if not isinstance(value, bool):
-            raise ValueError('Need a boolean value')
-        key = self._auth_key(authentication_token, prefix, method)
-        self._set_single(key, b'1' if value else b'0', AUTH_CACHE_EXPIRE)
+    def set_auth(self, authentication_token: str, value: int):
+        if not isinstance(value, int):
+            raise ValueError('Need an integer value')
+        self._set_single(authentication_token, str(value).encode('utf-8'), AUTH_CACHE_EXPIRE)
 
-    def get_auth(self, authentication_token: str, prefix: str, method: str):
-        key = self._auth_key(authentication_token, prefix, method)
-        allow = self._get_single(key)
-        if allow is None:
+    def get_auth(self, authentication_token: str) -> int:
+        user_id = self._get_single(authentication_token)
+        if user_id is None:
             raise KeyError('Element not found')
-        return allow == b'1'
+        return int(user_id)
 
     def _storage_key(self, storage_object):
         return self.STORAGE_PREFIX + file_key(storage_object)

--- a/src/blockserver/backend/database.py
+++ b/src/blockserver/backend/database.py
@@ -1,0 +1,99 @@
+from typing import List
+import psycopg2
+import psycopg2.extensions
+from abc import abstractmethod, ABC
+from uuid import UUID, uuid4
+import psycopg2.extras
+psycopg2.extras.register_uuid()
+from contextlib import contextmanager
+
+
+class AbstractUserDatabase(ABC):
+
+    DEFAULT_QUOTA = 2*1024*1024*8
+
+    @abstractmethod
+    def init_db(self):
+        pass
+
+    @abstractmethod
+    def drop_db(self):
+        pass
+
+    @abstractmethod
+    def create_prefix(self, user_id: int) -> UUID:
+        pass
+
+    @abstractmethod
+    def has_prefix(self, user_id: int, prefix: UUID) -> bool:
+        pass
+
+    @abstractmethod
+    def get_prefixes(self, user_id: int) -> List[UUID]:
+        pass
+
+
+class PostgresUserDatabase(AbstractUserDatabase):
+
+    SCHEMA = """
+    CREATE TABLE IF NOT EXISTS users (
+    id integer PRIMARY  KEY,
+    max_quota integer DEFAULT {0},
+    download_traffic bigint DEFAULT 0,
+    size bigint DEFAULT 0,
+    prefixes uuid[]
+    )
+    """.format(AbstractUserDatabase.DEFAULT_QUOTA)
+
+    def __init__(self, connection: psycopg2.extensions.connection):
+        self.connection = connection
+
+    @contextmanager
+    def cur(self):
+        with self.connection:
+            yield self.connection.cursor()  # type: psycopg2.extensions.cursor
+
+    def init_db(self):
+        with self.connection:
+            cur = self.connection.cursor()
+            cur.execute(self.SCHEMA)
+
+    def drop_db(self):
+        with self.cur() as cur:
+            cur.execute('DROP TABLE IF EXISTS users')
+
+    def create_prefix(self, user_id: int) -> UUID:
+        self.assert_user_exists(user_id)
+        with self.cur() as cur:
+            prefix = uuid4()
+            cur.execute(
+                'UPDATE users SET prefixes = prefixes || %s WHERE id=%s',
+                (prefix, user_id))
+            return prefix
+
+    def assert_user_exists(self, user_id):
+        with self.cur() as cur:
+            try:
+                cur.execute(
+                        'INSERT INTO users (id) VALUES (%s)',
+                        (user_id,))
+            except psycopg2.IntegrityError:
+                pass
+
+    def has_prefix(self, user_id: int, prefix: UUID) -> bool:
+        with self.cur() as cur:
+            cur.execute(
+                'SELECT 1 FROM users WHERE id=%s AND %s = ANY (prefixes)',
+                (user_id, prefix))
+            return cur.rowcount == 1
+
+    def get_prefixes(self, user_id: int) -> List[UUID]:
+        with self.cur() as cur:
+            cur.execute(
+                'SELECT prefixes FROM users WHERE id=%s',
+                (user_id,))
+            result = cur.fetchone()
+            if result is None:
+                return []
+            else:
+                return result[0]

--- a/src/blockserver/backend/util.py
+++ b/src/blockserver/backend/util.py
@@ -1,4 +1,6 @@
-from blockserver.backend.transfer import StorageObject
+from collections import namedtuple
 
+
+User = namedtuple('User', ['user_id', 'is_active'])
 
 

--- a/src/blockserver/server.py
+++ b/src/blockserver/server.py
@@ -10,7 +10,6 @@ import tornado.httpserver
 from functools import partial
 from tornado import concurrent
 from tornado import gen
-from tornado.httpclient import AsyncHTTPClient
 from tornado.options import define, options
 from tornado.web import Application, RequestHandler, stream_request_body
 

--- a/src/blockserver/server.py
+++ b/src/blockserver/server.py
@@ -293,7 +293,7 @@ def make_app(cache_cls=None, database_pool=None, debug=False):
         return DummyTransfer if options.dummy else S3Transfer
 
     if database_pool is None:
-        database_pool = SimpleConnectionPool(1, 20, dsn=options.psql_dsn),
+        database_pool = SimpleConnectionPool(1, 20, dsn=options.psql_dsn)
 
     application = Application([
         (r'^/api/v0/files/(?P<prefix>[\d\w-]+)/(?P<file_path>[/\d\w-]+)', FileHandler, dict(

--- a/src/blockserver/tests/test_auth.py
+++ b/src/blockserver/tests/test_auth.py
@@ -1,0 +1,101 @@
+from unittest.mock import Mock
+
+import pytest
+from glinda.testing import services
+from pytest import fixture
+
+from blockserver.backend import auth
+from blockserver.backend.auth import DummyAuth, Auth
+from conftest import make_coroutine
+
+
+@pytest.mark.gen_test
+def test_dummy_auth():
+    assert (yield DummyAuth.auth("Token RandomStuff")) == 0
+    assert (yield DummyAuth.auth("Foobar")) == 0
+    assert (yield DummyAuth.auth(None)) == 0
+
+
+@fixture
+def mock_auth(mocker):
+    mock = Mock()
+    mocker.patch('blockserver.backend.auth.AccountingServerAuth.request',
+                 new=make_coroutine(mock))
+    return mock
+
+
+@fixture
+def mock_cache(mocker):
+    return mocker.patch('blockserver.backend.auth.CacheAuth.auth')
+
+
+@pytest.mark.gen_test
+def test_auth(mock_auth, mock_cache):
+    mock_cache.return_value = None
+    token = Mock()
+    ret = Mock()
+    mock_auth.return_value = ret
+    assert (yield Auth.auth(token)) is ret
+    mock_auth.assert_called_once_with(token)
+    mock_cache.assert_called_once_with(token)
+
+
+@pytest.mark.gen_test
+def test_auth_cache(mock_auth, mock_cache):
+    token = Mock()
+    ret = Mock()
+    mock_cache.return_value = ret
+    assert (yield Auth.auth(token)) is ret
+    mock_cache.assert_called_once_with(token)
+    mock_auth.assert_not_called()
+
+
+@pytest.mark.gen_test
+def test_user_not_found(mock_auth):
+    mock_auth.return_value = None
+    uid = Mock()
+    with pytest.raises(auth.UserNotFound):
+        yield Auth.auth(uid)
+
+
+@pytest.mark.gen_test
+def test_auth_request(mocker):
+    fetch_mock = Mock()
+    mocker.patch('blockserver.backend.auth.AccountingServerAuth.send_request',
+                 new=make_coroutine(fetch_mock))
+    token = 'Token foobar'
+    ret = Mock()
+    ret.content = '{"user_id": 0}'
+    fetch_mock.return_value = ret
+    response = yield auth.AccountingServerAuth.request(token)
+    assert response == 0
+    fetch_mock.assert_called_once_with('{"auth": "Token foobar"}')
+
+
+@pytest.mark.gen_test
+def test_auth_send_request(app, http_client, auth_server):
+    path = '/api/v0/auth/'
+    body = b'{"user_id": 0}'
+    auth_server.add_response(services.Request('POST', path),
+                             services.Response(200, body=body))
+    response = yield auth.AccountingServerAuth.send_request(b'foobar')
+    assert response.code == 200
+    assert response.body == body
+
+
+@pytest.mark.gen_test
+def test_auth_send_request_not_found(app, http_client, auth_server):
+    path = '/api/v0/auth/'
+    auth_server.add_response(services.Request('POST', path),
+                             services.Response(404))
+    with pytest.raises(auth.UserNotFound):
+        yield auth.AccountingServerAuth.send_request(b'foobar')
+
+
+@pytest.mark.gen_test
+def test_auth_send_request_error_propagation(app, http_client, auth_server):
+    path = '/api/v0/auth/'
+    auth_server.add_response(services.Request('POST', path),
+                             services.Response(500))
+    with pytest.raises(auth.AuthError):
+        yield auth.AccountingServerAuth.send_request(b'foobar')

--- a/src/blockserver/tests/test_auth.py
+++ b/src/blockserver/tests/test_auth.py
@@ -6,15 +6,17 @@ from pytest import fixture
 
 from blockserver.backend import auth
 from blockserver.backend.auth import DummyAuth, Auth
+from blockserver.backend.util import User
 from conftest import make_coroutine
 
 
 @pytest.mark.gen_test
 def test_dummy_auth():
     cache = Mock()
-    assert (yield DummyAuth(cache).auth("Token RandomStuff")) == 0
-    assert (yield DummyAuth(cache).auth("Foobar")) == 0
-    assert (yield DummyAuth(cache).auth(None)) == 0
+    user = User(user_id=0, is_active=True)
+    assert (yield DummyAuth(cache).auth("Token RandomStuff")) == user
+    assert (yield DummyAuth(cache).auth("Foobar")) == user
+    assert (yield DummyAuth(cache).auth(None)) == user
 
 
 @fixture

--- a/src/blockserver/tests/test_auth.py
+++ b/src/blockserver/tests/test_auth.py
@@ -138,3 +138,16 @@ def test_auth_returns_inactive_user_object(app, http_client, auth_server):
     user = yield auth.AccountingServerAuth.request('foobar')
     assert user.user_id == 0
     assert not user.is_active
+
+
+@pytest.mark.gen_test
+def test_content_type_header_set(app, http_client, auth_server):
+    path = '/api/v0/auth/'
+    body = b'{"user_id": 0}'
+    auth_server.add_response(services.Request('POST', path),
+                             services.Response(200, body=body))
+    response = yield auth.AccountingServerAuth.send_request('foobar')
+    assert response.code == 200
+    request = auth_server.get_request(path)
+    assert request.headers['Content-Type'] == 'application/json'
+

--- a/src/blockserver/tests/test_cache.py
+++ b/src/blockserver/tests/test_cache.py
@@ -15,18 +15,16 @@ def test_storage_cache_basics(cache):
     assert cache.get_storage(without_etag) == with_etag
 
 
-token_and_prefix_get = 'MAGICFAIRYTALE', 'EXAMPLEPREFIX', 'get'
-token_and_prefix_post = 'MAGICFAIRYTALE', 'EXAMPLEPREFIX', 'post'
-token_and_prefix_delete = 'MAGICFAIRYTALE', 'EXAMPLEPREFIX', 'delete'
+AUTH_TOKEN = 'MAGICFAIRYTALE'
 
 
 def test_auth_cache_basics(cache):
     with pytest.raises(KeyError):
-        cache.get_auth(*token_and_prefix_get)
+        cache.get_auth(AUTH_TOKEN)
     with pytest.raises(ValueError):
-        cache.set_auth(*token_and_prefix_get, None)
-    cache.set_auth(*token_and_prefix_get, True)
-    assert cache.get_auth(*token_and_prefix_get) == True
-    cache.set_auth(*token_and_prefix_get, False)
-    assert cache.get_auth(*token_and_prefix_get) == False
+        cache.set_auth(AUTH_TOKEN, None)
+    cache.set_auth(AUTH_TOKEN, 1)
+    assert cache.get_auth(AUTH_TOKEN) == 1
+    cache.set_auth(AUTH_TOKEN, 2)
+    assert cache.get_auth(AUTH_TOKEN) == 2
 

--- a/src/blockserver/tests/test_cache.py
+++ b/src/blockserver/tests/test_cache.py
@@ -1,6 +1,7 @@
 import pytest
 
 from blockserver.backend.transfer import StorageObject
+from blockserver.backend.auth import User
 
 with_etag = StorageObject('foo', 'bar', 'etag', size=10)
 without_etag = with_etag._replace(etag=None, size=None)  # type: StorageObject
@@ -23,8 +24,10 @@ def test_auth_cache_basics(cache):
         cache.get_auth(AUTH_TOKEN)
     with pytest.raises(ValueError):
         cache.set_auth(AUTH_TOKEN, None)
-    cache.set_auth(AUTH_TOKEN, 1)
-    assert cache.get_auth(AUTH_TOKEN) == 1
-    cache.set_auth(AUTH_TOKEN, 2)
-    assert cache.get_auth(AUTH_TOKEN) == 2
+    user = User(0, True)
+    cache.set_auth(AUTH_TOKEN, user)
+    assert cache.get_auth(AUTH_TOKEN) == user
+    user_2 = User(2, False)
+    cache.set_auth(AUTH_TOKEN, user_2)
+    assert cache.get_auth(AUTH_TOKEN) == user_2
 

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -1,0 +1,46 @@
+from blockserver.backend.database import AbstractUserDatabase, PostgresUserDatabase
+from blockserver import server
+import uuid
+UID = 1
+
+
+def test_default_quota():
+    assert AbstractUserDatabase.DEFAULT_QUOTA > 0
+    assert str(AbstractUserDatabase.DEFAULT_QUOTA) in PostgresUserDatabase.SCHEMA
+
+
+def test_create_prefix(pg_db: PostgresUserDatabase):
+    prefix = pg_db.create_prefix(UID)
+    assert pg_db.has_prefix(UID, prefix)
+    another_prefix = uuid.uuid4()
+    assert not pg_db.has_prefix(UID, another_prefix)
+    second_prefix = pg_db.create_prefix(UID)
+    assert pg_db.has_prefix(UID, second_prefix)
+
+
+def test_create_multiple_prefixes(pg_db: PostgresUserDatabase):
+    prefix = pg_db.create_prefix(UID)
+    prefix_2 = pg_db.create_prefix(UID)
+    assert prefix != prefix_2
+
+
+def test_assert_user_exists(pg_db):
+    pg_db.assert_user_exists(UID)
+    pg_db.assert_user_exists(UID)
+
+
+def test_retrieve_prefixes(pg_db):
+    p1 = pg_db.create_prefix(UID)
+    p2 = pg_db.create_prefix(UID)
+    prefixes = pg_db.get_prefixes(UID)
+    assert isinstance(prefixes[0], uuid.UUID)
+    assert set(prefixes) == {p1, p2}
+
+
+def test_nonexistent_prefixes(pg_db):
+    assert pg_db.get_prefixes(UID) == []
+
+
+def test_idempotent_init_db(pg_db):
+    pg_db.init_db()
+    pg_db.init_db()

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -50,21 +50,24 @@ def test_used_space_inc(pg_db, user_id, prefix):
     size = 500
     second_prefix = pg_db.create_prefix(user_id)
     pg_db.update_size(prefix, size)
-    assert pg_db.get_size(prefix) == size
+    assert pg_db.get_size(user_id) == size
 
     pg_db.update_size(second_prefix, size)
-    assert pg_db.get_size(prefix) == size * 2
+    assert pg_db.get_size(user_id) == size * 2
 
 
 def test_used_space_dec(pg_db, user_id, prefix):
     size = 500
     second_prefix = pg_db.create_prefix(user_id)
     pg_db.update_size(prefix, size)
-    assert pg_db.get_size(prefix) == size
+    assert pg_db.get_size(user_id) == size
 
     pg_db.update_size(second_prefix, -size)
-    assert pg_db.get_size(prefix) == 0
+    assert pg_db.get_size(user_id) == 0
 
 
-def test_traffic_for_user():
-    pytest.fail('Not implemented')
+def test_traffic_for_prefix(pg_db, user_id, prefix):
+    assert pg_db.get_traffic(user_id) == 0
+    amount = 500
+    pg_db.update_traffic(prefix, amount)
+    assert pg_db.get_traffic(user_id) == amount

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -34,7 +34,6 @@ def test_retrieve_prefixes(pg_db):
     p1 = pg_db.create_prefix(UID)
     p2 = pg_db.create_prefix(UID)
     prefixes = pg_db.get_prefixes(UID)
-    assert isinstance(prefixes[0], uuid.UUID)
     assert set(prefixes) == {p1, p2}
 
 
@@ -47,12 +46,24 @@ def test_idempotent_init_db(pg_db):
     pg_db.init_db()
 
 
-def test_used_space_inc():
-    pytest.fail('Not implemented')
+def test_used_space_inc(pg_db, user_id, prefix):
+    size = 500
+    second_prefix = pg_db.create_prefix(user_id)
+    pg_db.update_size(prefix, size)
+    assert pg_db.get_size(prefix) == size
+
+    pg_db.update_size(second_prefix, size)
+    assert pg_db.get_size(prefix) == size * 2
 
 
-def test_used_space_dec():
-    pytest.fail('Not implemented')
+def test_used_space_dec(pg_db, user_id, prefix):
+    size = 500
+    second_prefix = pg_db.create_prefix(user_id)
+    pg_db.update_size(prefix, size)
+    assert pg_db.get_size(prefix) == size
+
+    pg_db.update_size(second_prefix, -size)
+    assert pg_db.get_size(prefix) == 0
 
 
 def test_traffic_for_user():

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -1,5 +1,6 @@
+import pytest
+
 from blockserver.backend.database import AbstractUserDatabase, PostgresUserDatabase
-from blockserver import server
 import uuid
 UID = 1
 
@@ -44,3 +45,15 @@ def test_nonexistent_prefixes(pg_db):
 def test_idempotent_init_db(pg_db):
     pg_db.init_db()
     pg_db.init_db()
+
+
+def test_used_space_inc():
+    pytest.fail('Not implemented')
+
+
+def test_used_space_dec():
+    pytest.fail('Not implemented')
+
+
+def test_traffic_for_user():
+    pytest.fail('Not implemented')

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -13,7 +13,7 @@ def test_default_quota():
 def test_create_prefix(pg_db: PostgresUserDatabase):
     prefix = pg_db.create_prefix(UID)
     assert pg_db.has_prefix(UID, prefix)
-    another_prefix = uuid.uuid4()
+    another_prefix = str(uuid.uuid4())
     assert not pg_db.has_prefix(UID, another_prefix)
     second_prefix = pg_db.create_prefix(UID)
     assert pg_db.has_prefix(UID, second_prefix)

--- a/src/blockserver/tests/test_manage.py
+++ b/src/blockserver/tests/test_manage.py
@@ -1,0 +1,38 @@
+import manage
+
+
+def test_args(mocker):
+    dsn = "foobar"
+    initdb = mocker.patch('blockserver.manage.initdb')
+    dropdb = mocker.patch('blockserver.manage.dropdb')
+    arguments = ['initdb', '--psql-dsn', dsn]
+    manage.main(arguments)
+    initdb.assert_called_with(dsn)
+
+    arguments = ['dropdb', '--psql-dsn', dsn]
+    manage.main(arguments)
+    dropdb.assert_called_with(dsn)
+
+
+def test_initdb(mocker):
+    db_init = mocker.patch('blockserver.backend.database.PostgresUserDatabase.init_db')
+    db = mocker.patch('blockserver.backend.database.PostgresUserDatabase.__init__')
+    db.return_value = None
+    connect = mocker.patch('psycopg2.connect')
+    dsn = 'foobar'
+    manage.initdb(dsn)
+    connect.assert_called_with(dsn)
+    db.assert_called_with(connect.return_value)
+    db_init.assert_called_with()
+
+
+def test_drobdb(mocker):
+    db_drop = mocker.patch('blockserver.backend.database.PostgresUserDatabase.drop_db')
+    db = mocker.patch('blockserver.backend.database.PostgresUserDatabase.__init__')
+    db.return_value = None
+    connect = mocker.patch('psycopg2.connect')
+    dsn = 'foobar'
+    manage.dropdb(dsn)
+    connect.assert_called_with(dsn)
+    db.assert_called_with(connect.return_value)
+    db_drop.assert_called_with()

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -3,34 +3,7 @@ import json
 from tornado.options import options
 from glinda.testing import services
 
-from blockserver import server
-
-
-API_QUOTA = '/api/v0/quota/'
-
-
-@pytest.fixture
-def mock_log():
-    async def log(*args):
-        log.log.append(args)
-    log.log = []
-    return log
-
-
-@pytest.yield_fixture
-def app(mock_log, cache):
-    prev_auth = options.dummy_auth
-    prev_log = options.dummy_log
-    options.dummy_auth = 'MAGICFARYDUST'
-    options.dummy_log = True
-    yield server.make_app(
-            cache_cls=lambda: (lambda: cache),
-            log_callback=lambda: mock_log if options.dummy_log else server.send_log,
-            debug=True)
-    options.dummy_auth = prev_auth
-    options.dummy_log = prev_log
-
-
+API_QUOTA = '/api/v0/quota'
 @pytest.mark.gen_test
 def test_not_found(backend, http_client, path):
     response = yield http_client.fetch(path, raise_error=False)

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -119,7 +119,7 @@ def test_upload_successful():
 def test_save_log(app, mocker, http_client, path, auth_path, headers,
                   auth_server, file_path, prefix):
     quota_log = mocker.patch(
-        'blockserver.backend.database.PostgresUserDatabase.update_quota')
+        'blockserver.backend.database.PostgresUserDatabase.update_size')
     trafifc_log = mocker.patch(
         'blockserver.backend.database.PostgresUserDatabase.update_traffic')
     body = b'Dummy'
@@ -145,7 +145,7 @@ def test_log_handles_overwrites(app, mocker, auth_server, auth_path,
     body_larger = b'DummyDummy'
     size = len(body)
     quota_log = mocker.patch(
-        'blockserver.backend.database.PostgresUserDatabase.update_quota')
+        'blockserver.backend.database.PostgresUserDatabase.update_size')
 
     auth_server.add_response(services.Request('POST', auth_path),
                              services.Response(200, body=b'{"user_id": 0, "active":true}'))

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -4,10 +4,15 @@ import os
 import random
 import string
 import blockserver.backend.cache as cache_backends
+import blockserver.server
 from blockserver.backend import transfer as transfer_module
+from pytest_dbfixtures.factories.postgresql import init_postgresql_database
+from pytest_dbfixtures.utils import try_import
 
 from glinda.testing import services
 from tornado.options import options
+
+from blockserver.backend.database import PostgresUserDatabase
 
 
 @pytest.fixture
@@ -86,6 +91,56 @@ def cache(request):
     cache_object.flush()
     return cache_object
 
+
+@pytest.fixture(scope='session')
+def pg_connection(request, postgresql_proc):
+    psycopg2, config = try_import('psycopg2', request)
+    pg_host = postgresql_proc.host
+    pg_port = postgresql_proc.port
+    pg_db = config.postgresql.db
+
+    init_postgresql_database(
+            psycopg2, config.postgresql.user, pg_host, pg_port, pg_db
+    )
+    conn = psycopg2.connect(
+            dbname=pg_db,
+            user=config.postgresql.user,
+            host=pg_host,
+            port=pg_port
+    )
+    return conn
+
+
+@pytest.fixture
+def pg_db(pg_connection):
+    db = PostgresUserDatabase(pg_connection)
+    db.drop_db()
+    db.init_db()
+    return db
+
+
+@pytest.fixture
+def mock_log():
+    async def log(*args):
+        log.log.append(args)
+    log.log = []
+    return log
+
+
+@pytest.yield_fixture
+def app(mock_log, cache):
+    prev_auth = options.dummy_auth
+    prev_log = options.dummy_log
+    options.dummy_auth = 'MAGICFARYDUST'
+    options.dummy_log = True
+    yield blockserver.server.make_app(
+            cache_cls=lambda: (lambda: cache),
+            log_callback=lambda: mock_log if options.dummy_log else blockserver.server.send_log,
+            debug=True)
+    options.dummy_auth = prev_auth
+    options.dummy_log = prev_log
+
+
 @pytest.yield_fixture()
 def transfer(request, cache):
     transfer_backend = request.param
@@ -120,3 +175,10 @@ def pytest_generate_tests(metafunc):
         if not metafunc.config.option.dummy_cache:
             backends.append('redis')
         metafunc.parametrize("cache", backends, indirect=True)
+
+
+def make_coroutine(mock):
+    async def coroutine(*args, **kwargs):
+        return mock(*args, **kwargs)
+
+    return coroutine

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -59,8 +59,8 @@ def file_path():
 
 
 @pytest.fixture
-def auth_path(file_path):
-    return '/api/v0/auth' + file_path
+def auth_path():
+    return '/api/v0/auth/'
 
 
 @pytest.fixture

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -59,6 +59,10 @@ def file_path(prefix):
 
 
 @pytest.fixture
+def prefix_path(base_url):
+    return base_url + '/api/v0/prefix/'
+
+@pytest.fixture
 def auth_path():
     return '/api/v0/auth/'
 

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -53,8 +53,8 @@ def auth_server(service_layer):
 
 
 @pytest.fixture
-def file_path():
-    return '/test/' + ''.join(random.choice(string.ascii_lowercase + string.digits)
+def file_path(prefix):
+    return '/{}/'.format(prefix) + ''.join(random.choice(string.ascii_lowercase + string.digits)
                           for _ in range(12))
 
 

--- a/src/manage.py
+++ b/src/manage.py
@@ -1,0 +1,40 @@
+import argparse
+import psycopg2
+from blockserver.backend.database import PostgresUserDatabase
+
+
+def _connect(dsn):
+    connection = psycopg2.connect(dsn)
+    db = PostgresUserDatabase(connection)
+    return db
+
+
+def initdb(dsn):
+    db = _connect(dsn)
+    db.init_db()
+
+
+def dropdb(dsn):
+    db = _connect(dsn)
+    db.drop_db()
+
+
+def parse_args(arguments):
+    parser = argparse.ArgumentParser(description='Manage qabel-block')
+    parser.add_argument('action', choices=('initdb', 'dropdb'))
+    parser.add_argument('--psql-dsn', metavar='DSN', required=True)
+    return parser.parse_args(arguments)
+
+
+def main(arguments=None):
+    args = parse_args(arguments)
+    if args.action == 'initdb':
+        initdb(args.psql_dsn)
+    elif args.action == 'dropdb':
+        dropdb(args.psql_dsn)
+
+if __name__ == '__main__':
+    main()
+
+
+


### PR DESCRIPTION
Quota-relevant logging is done in the servers own database.

New resource: /api/v0/prefix to create and get prefixes.