### PR TITLE
Prevent 500 on GET 404s for unknown prefixes

### DIFF
--- a/src/blockserver/backend/database.py
+++ b/src/blockserver/backend/database.py
@@ -118,9 +118,11 @@ class PostgresUserDatabase(AbstractUserDatabase):
         with self._cur() as cur:
             cur.execute('SELECT download_traffic FROM users JOIN prefixes USING (user_id)'
                         'WHERE name = %s', (prefix,))
-            traffic, = cur.fetchone()
-            if traffic is None:
+            result = cur.fetchone()
+            if result is None:
                 traffic = 0
+            else:
+                traffic, = result
             return traffic
 
     def set_quota(self, user_id: int, quota: int):

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -95,3 +95,7 @@ def test_traffic_by_prefix(pg_db, prefix):
 def test_quota_reached_by_large_file(pg_db, user_id, prefix):
     size = 3*1024**3
     assert pg_db.quota_reached(user_id, size)
+
+
+def test_traffic_default(pg_db):
+    assert pg_db.get_traffic_by_prefix("non existing prefix") == 0

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -239,3 +239,10 @@ def test_quota_delete_and_download(backend, http_client, prefix, path, headers, 
     assert b'Quota reached' in response.body
     response = yield http_client.fetch(path, method='DELETE', headers=headers)
     assert response.code == 204
+
+
+@pytest.mark.gen_test
+def test_get_before_post(backend, http_client, base_url):
+    url = base_url + '/api/v0/files/randomprefix/foobar'
+    response = yield http_client.fetch(url, method='GET', raise_error=False)
+    assert response.code == 404


### PR DESCRIPTION
Fix the "NoneType not iterable" in get_traffic_by_prefix for a GET on an unknown prefix.

Fixes #19 