### PR TITLE
Large cleanup and refactoring of auth

### DIFF
--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -28,7 +28,7 @@ class DummyAuth:
 
     async def auth(self, auth_header: str) -> int:
         if auth_header == 'Token {}'.format(options.dummy_auth):
-            raise BypassAuth(User(user_id=0, is_active=True))
+            return User(user_id=0, is_active=True)
         else:
             raise UserNotFound()
 

--- a/src/blockserver/backend/database.py
+++ b/src/blockserver/backend/database.py
@@ -94,7 +94,8 @@ class PostgresUserDatabase(AbstractUserDatabase):
                 (user_id,))
             result = cur.fetchone()
             if result is None:
-                return self.DEFAULT_QUOTA, 0
+                self.assert_user_exists(user_id)
+                return self.get_size(user_id)
             else:
                 return result
 

--- a/src/blockserver/backend/database.py
+++ b/src/blockserver/backend/database.py
@@ -154,7 +154,7 @@ class PostgresUserDatabase(AbstractUserDatabase):
             result = cur.fetchone()
             if result is None:
                 self.assert_user_exists(user_id)
-                return self.quota_reached(user_id)
+                return self.quota_reached(user_id, file_size)
             reached, = result
             return reached
 

--- a/src/blockserver/backend/quota.py
+++ b/src/blockserver/backend/quota.py
@@ -16,6 +16,3 @@ class QuotaPolicy:
     def download(current_traffic):
         return current_traffic <= QuotaPolicy.TRAFFIC_THRESHOLD
 
-    @staticmethod
-    def delete():
-        return True

--- a/src/blockserver/backend/transfer.py
+++ b/src/blockserver/backend/transfer.py
@@ -156,9 +156,8 @@ class DummyTransfer(AbstractTransfer):
             cached = self._from_cache(storage_object)
         except KeyError:
             try:
-                size = os.path.getsize(
+                return os.path.getsize(
                     files[file_key(storage_object)].local_file)
-                return size
             except KeyError:
                 return None
         else:
@@ -191,8 +190,9 @@ class DummyTransfer(AbstractTransfer):
             if cached.etag == storage_object.etag:
                 return storage_object._replace(local_file=None)
 
-        object = files.get(file_key(storage_object), None)
-        if object is None:
+        try:
+            object = files[file_key(storage_object)]
+        except KeyError:
             return None
         if storage_object.etag == object.etag:
             return storage_object._replace(local_file=None)

--- a/src/blockserver/tests/test_auth.py
+++ b/src/blockserver/tests/test_auth.py
@@ -13,8 +13,9 @@ from conftest import make_coroutine
 @pytest.mark.gen_test
 def test_dummy_auth():
     cache = Mock()
-    with pytest.raises(auth.BypassAuth):
-        yield DummyAuth(cache).auth("Token {}".format(options.dummy_auth))
+    user = yield DummyAuth(cache).auth("Token {}".format(options.dummy_auth))
+    assert user.user_id == 0
+    assert user.is_active
     with pytest.raises(auth.UserNotFound):
         yield DummyAuth(cache).auth("Foobar")
     with pytest.raises(auth.UserNotFound):

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -99,3 +99,7 @@ def test_quota_reached_by_large_file(pg_db, user_id, prefix):
 
 def test_traffic_default(pg_db):
     assert pg_db.get_traffic_by_prefix("non existing prefix") == 0
+
+
+def test_quota_reached_recursion(pg_db):
+    assert not pg_db.quota_reached(1, 1)

--- a/src/blockserver/tests/test_quota.py
+++ b/src/blockserver/tests/test_quota.py
@@ -28,7 +28,3 @@ def test_traffic_limit(quota_policy):
     quota_policy.TRAFFIC_THRESHOLD = 10
     assert quota_policy.download(10)
     assert not quota_policy.download(11)
-
-
-def test_delete_policy(quota_policy):
-    assert quota_policy.delete()

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -268,8 +268,9 @@ def test_database_finish_called_in_prefix(backend, http_client, base_url, mocker
 
 
 @pytest.mark.gen_test
-def test_database_finish_called_in_quota(backend, http_client, base_url, mocker):
+def test_database_finish_called_in_quota(backend, http_client, headers, base_url, mocker):
     finish_db = mocker.patch('blockserver.server.DatabaseMixin.finish_database')
     url = base_url + '/api/v0/quota/'
-    yield http_client.fetch(url, method='GET')
+    response = yield http_client.fetch(url, method='GET', headers=headers, raise_error=True)
+    assert response.code == 200, response.body.decode('utf-8')
     finish_db.assert_called_with()

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -252,8 +252,24 @@ def test_get_before_post(backend, http_client, base_url):
 
 
 @pytest.mark.gen_test
-def test_database_finish_called(backend, http_client, base_url, mocker):
+def test_database_finish_called_in_files(backend, http_client, base_url, mocker):
     finish_db = mocker.patch('blockserver.server.DatabaseMixin.finish_database')
     url = base_url + '/api/v0/files/randomprefix/foobar'
     yield http_client.fetch(url, method='GET', raise_error=False)
+    finish_db.assert_called_with()
+
+
+@pytest.mark.gen_test
+def test_database_finish_called_in_prefix(backend, http_client, base_url, mocker, headers):
+    finish_db = mocker.patch('blockserver.server.DatabaseMixin.finish_database')
+    url = base_url + '/api/v0/prefix/'
+    yield http_client.fetch(url, method='GET', headers=headers)
+    finish_db.assert_called_with()
+
+
+@pytest.mark.gen_test
+def test_database_finish_called_in_quota(backend, http_client, base_url, mocker):
+    finish_db = mocker.patch('blockserver.server.DatabaseMixin.finish_database')
+    url = base_url + '/api/v0/quota/'
+    yield http_client.fetch(url, method='GET')
     finish_db.assert_called_with()

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -79,8 +79,8 @@ def auth_path():
     return '/api/v0/auth/'
 
 @pytest.fixture
-def block_path(base_url, file_path):
-    return base_url + '/api/v0/files/block' + file_path
+def block_path(base_url, prefix):
+    return base_url + '/api/v0/files/{}/block/foobar'.format(prefix)
 
 @pytest.fixture
 def path(base_url, file_path):


### PR DESCRIPTION
* Use HTTPError und Finish for flow control
* Remove QuotaPolicy.delete
* Remove ByPassAuth exception
* Remove FileHandler.authorized attribute
* Fix block-path fixture

Hopefully this will resolve the issue #21 where .finish() was called twice since I can't recreate that error in a test.