### PR TITLE
Enable xheader support

### DIFF
--- a/src/blockserver/server.py
+++ b/src/blockserver/server.py
@@ -304,7 +304,8 @@ def main():
     if options.debug:
         application.listen(address=options.address, port=options.port)
     else:
-        server = tornado.httpserver.HTTPServer(application)
+        server = tornado.httpserver.HTTPServer(application,
+                                               xheaders=True)
         server.bind(options.port)
         server.start()
     if options.asyncio:


### PR DESCRIPTION
See http://www.tornadoweb.org/en/stable/httpserver.html
It is just a config option in the HttpServer

Resolves #25 