### PR TITLE
Respect quota from accounting server; monthly traffic log

### DIFF
--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -22,13 +22,18 @@ class BypassAuth(AuthError):
 
 
 class DummyAuth:
+    QUOTA = 2 * 1024**3
+    TRAFFIC_QUOTA = 20 * 1024**3
 
     def __init__(self, cache_backend):
         pass
 
     async def auth(self, auth_header: str) -> int:
         if auth_header == 'Token {}'.format(options.dummy_auth):
-            raise BypassAuth(User(user_id=0, is_active=True))
+            raise BypassAuth(User(user_id=0,
+                                  is_active=True,
+                                  quota=self.QUOTA,
+                                  traffic_quota=self.TRAFFIC_QUOTA))
         else:
             raise UserNotFound()
 
@@ -63,7 +68,10 @@ class AccountingServerAuth:
             raise AuthError(e)
 
         try:
-            return User(user_id=body.get('user_id'), is_active=body.get('active'))
+            return User(user_id=body['user_id'],
+                        is_active=body['active'],
+                        quota=body['block_quota'],
+                        traffic_quota=body['monthly_traffic_quota'])
         except KeyError:
             raise UserNotFound('Invalid response from accounting server')
 

--- a/src/blockserver/backend/auth.py
+++ b/src/blockserver/backend/auth.py
@@ -81,18 +81,17 @@ class AccountingServerAuth:
     @mon.time(mon.WAIT_FOR_AUTH)
     async def request_auth(auth_header: str) -> User:
         return await AccountingServerAuth.api_request({'auth': auth_header},
-                                                      AccountingServerAuth.auth_url())
+                                                      )
 
     @staticmethod
     @mon.time(mon.WAIT_FOR_AUTH)
     async def request_info(user_id: int) -> User:
-        return await AccountingServerAuth.api_request({'id': user_id},
-                                                      AccountingServerAuth.info_url())
+        return await AccountingServerAuth.api_request({'user_id': user_id})
 
     @staticmethod
-    async def api_request(request_data, url):
+    async def api_request(request_data):
         request_body = json.dumps(request_data)
-        response = await AccountingServerAuth.send_request(request_body, url)
+        response = await AccountingServerAuth.send_request(request_body)
         try:
             body = json.loads(response.body.decode('utf-8'))
         except json.JSONDecodeError as e:
@@ -107,9 +106,9 @@ class AccountingServerAuth:
             raise UserNotFound('Invalid response from accounting server')
 
     @staticmethod
-    async def send_request(request_body, url=None):
+    async def send_request(request_body):
         http_client = AsyncHTTPClient()
-        url = url or AccountingServerAuth.auth_url()
+        url = AccountingServerAuth.auth_url()
         try:
             return await http_client.fetch(
                 url, headers={
@@ -128,11 +127,7 @@ class AccountingServerAuth:
 
     @staticmethod
     def auth_url():
-        return options.accounting_host + '/api/v0/auth/'
-
-    @staticmethod
-    def info_url():
-        return options.accounting_host + '/api/v0/auth/info/'
+        return options.accounting_host + '/api/v0/internal/user/'
 
 
 class CacheAuth:

--- a/src/blockserver/backend/cache.py
+++ b/src/blockserver/backend/cache.py
@@ -41,16 +41,22 @@ class AbstractCache(ABC):
     def set_auth(self, authentication_token: str, user: User):
         if not isinstance(user, User):
             raise ValueError('Need a User object')
-        self._set(authentication_token, user_id=str(user.user_id).encode('utf-8'),
-                  is_active=str(int(user.is_active)).encode('utf-8'))
+        self._set(authentication_token,
+                  user_id=str(user.user_id).encode(),
+                  is_active=str(int(user.is_active)).encode(),
+                  quota=str(int(user.quota)).encode(),
+                  traffic_quota=str(int(user.traffic_quota)).encode())
         self._set_expire(authentication_token, AUTH_CACHE_EXPIRE)
 
     def get_auth(self, authentication_token: str) -> int:
-        user_info = self._get(authentication_token, 'user_id', 'is_active')
-        user_id, is_active = user_info
+        user_info = self._get(authentication_token, 'user_id', 'is_active', 'quota', 'traffic_quota')
+        user_id, is_active, quota, traffic_quota = user_info
         if user_id is None:
             raise KeyError('Element not found')
-        return User(user_id=int(user_id.decode('utf-8')), is_active=(is_active == b'1'))
+        return User(user_id=int(user_id.decode('utf-8')),
+                    is_active=(is_active == b'1'),
+                    quota=int(quota.decode()),
+                    traffic_quota=int(traffic_quota.decode()))
 
     def _storage_key(self, storage_object):
         return self.STORAGE_PREFIX + file_key(storage_object)

--- a/src/blockserver/backend/cache.py
+++ b/src/blockserver/backend/cache.py
@@ -60,7 +60,7 @@ class AbstractCache(ABC):
     def _get_user(self, key: str) -> User:
         user_info = self._get(key, 'user_id', 'is_active', 'quota', 'traffic_quota')
         user_id, is_active, quota, traffic_quota = user_info
-        if user_id is None:
+        if any(attr is None for attr in user_info):
             raise KeyError('Element not found')
         return User(user_id=int(user_id.decode('utf-8')),
                     is_active=(is_active == b'1'),

--- a/src/blockserver/backend/quota.py
+++ b/src/blockserver/backend/quota.py
@@ -12,6 +12,3 @@ class QuotaPolicy:
             return False
         return is_overwrite and file_size < QuotaPolicy.METAFILE_THRESHOLD
 
-    @staticmethod
-    def download(current_traffic):
-        return current_traffic <= QuotaPolicy.TRAFFIC_THRESHOLD

--- a/src/blockserver/backend/util.py
+++ b/src/blockserver/backend/util.py
@@ -1,4 +1,4 @@
 from collections import namedtuple
 
 
-User = namedtuple('User', ['user_id', 'is_active'])
+User = namedtuple('User', ['user_id', 'is_active', 'quota', 'traffic_quota'])

--- a/src/blockserver/backend/util.py
+++ b/src/blockserver/backend/util.py
@@ -1,4 +1,10 @@
+import datetime
 from collections import namedtuple
 
 
 User = namedtuple('User', ['user_id', 'is_active', 'quota', 'traffic_quota'])
+
+
+def this_month():
+    """Return datetime.date for the current month (day=1)."""
+    return datetime.date.today().replace(day=1)

--- a/src/blockserver/server.py
+++ b/src/blockserver/server.py
@@ -156,7 +156,7 @@ class FileHandler(DatabaseMixin, RequestHandler):
         current_traffic = db.get_traffic_by_prefix(prefix)
         prefix_owner = db.get_prefix_owner(prefix)
         if prefix_owner is None:
-            return  # prefix does not exist, will be rejected later (TODO: move)
+            return  # prefix does not exist, will 404 later
         permitted_traffic = (await self.auth_callback.get_user(prefix_owner)).traffic_quota
         if current_traffic > permitted_traffic:
             # TODO: the download traffic quota should probably be a soft-quota, not hard (i.e. limit bandwidth or

--- a/src/blockserver/tests/test_auth.py
+++ b/src/blockserver/tests/test_auth.py
@@ -91,12 +91,12 @@ def test_auth_request(mocker):
     fetch_mock.return_value = ret
     response = yield auth.AccountingServerAuth.request_auth(token)
     assert response == auth.User(user_id=0, is_active=True, quota=512, traffic_quota=1024)
-    fetch_mock.assert_called_once_with('{"auth": "Token foobar"}', auth.AccountingServerAuth.auth_url())
+    fetch_mock.assert_called_once_with('{"auth": "Token foobar"}')
 
 
 @pytest.mark.gen_test
 def test_auth_send_request(app, http_client, auth_server):
-    path = '/api/v0/auth/'
+    path = '/api/v0/internal/user/'
     body = b'{"user_id": 0}'
     auth_server.add_response(services.Request('POST', path),
                              services.Response(200, body=body))
@@ -107,7 +107,7 @@ def test_auth_send_request(app, http_client, auth_server):
 
 @pytest.mark.gen_test
 def test_auth_send_request_not_found(app, http_client, auth_server):
-    path = '/api/v0/auth/'
+    path = '/api/v0/internal/user/'
     auth_server.add_response(services.Request('POST', path),
                              services.Response(404))
     with pytest.raises(auth.UserNotFound):
@@ -116,7 +116,7 @@ def test_auth_send_request_not_found(app, http_client, auth_server):
 
 @pytest.mark.gen_test
 def test_auth_send_request_error_propagation(app, http_client, auth_server):
-    path = '/api/v0/auth/'
+    path = '/api/v0/internal/user/'
     auth_server.add_response(services.Request('POST', path),
                              services.Response(500))
     with pytest.raises(auth.AuthError):
@@ -125,7 +125,7 @@ def test_auth_send_request_error_propagation(app, http_client, auth_server):
 
 @pytest.mark.gen_test
 def test_auth_returns_user_object(app, http_client, auth_server):
-    path = '/api/v0/auth/'
+    path = '/api/v0/internal/user/'
     body = b'{"user_id": 0, "active": true, "block_quota": 512, "monthly_traffic_quota": 123456789}'
     auth_server.add_response(services.Request('POST', path),
                              services.Response(200, body=body))
@@ -139,7 +139,7 @@ def test_auth_returns_user_object(app, http_client, auth_server):
 
 @pytest.mark.gen_test
 def test_auth_returns_inactive_user_object(app, http_client, auth_server):
-    path = '/api/v0/auth/'
+    path = '/api/v0/internal/user/'
     body = b'{"user_id": 0, "active": false, "block_quota": 512, "monthly_traffic_quota": 123456789}'
     auth_server.add_response(services.Request('POST', path),
                              services.Response(200, body=body))
@@ -150,7 +150,7 @@ def test_auth_returns_inactive_user_object(app, http_client, auth_server):
 
 @pytest.mark.gen_test
 def test_content_type_header_set(app, http_client, auth_server):
-    path = '/api/v0/auth/'
+    path = '/api/v0/internal/user/'
     body = b'{"user_id": 0}'
     auth_server.add_response(services.Request('POST', path),
                              services.Response(200, body=body))

--- a/src/blockserver/tests/test_cache.py
+++ b/src/blockserver/tests/test_cache.py
@@ -30,3 +30,9 @@ def test_auth_cache_basics(cache):
     user_2 = User(2, False, 456, 123789)
     cache.set_auth(AUTH_TOKEN, user_2)
     assert cache.get_auth(AUTH_TOKEN) == user_2
+
+
+def test_auth_cache_old_data(cache):
+    cache._set('some_token', user_id=3, is_active=True)
+    with pytest.raises(KeyError):
+        cache.get_auth('some_token')

--- a/src/blockserver/tests/test_cache.py
+++ b/src/blockserver/tests/test_cache.py
@@ -24,9 +24,9 @@ def test_auth_cache_basics(cache):
         cache.get_auth(AUTH_TOKEN)
     with pytest.raises(ValueError):
         cache.set_auth(AUTH_TOKEN, None)
-    user = User(0, True)
+    user = User(0, True, 123, 456)
     cache.set_auth(AUTH_TOKEN, user)
     assert cache.get_auth(AUTH_TOKEN) == user
-    user_2 = User(2, False)
+    user_2 = User(2, False, 456, 123789)
     cache.set_auth(AUTH_TOKEN, user_2)
     assert cache.get_auth(AUTH_TOKEN) == user_2

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -35,6 +35,14 @@ def test_retrieve_prefixes(pg_db):
     assert set(prefixes) == {p1, p2}
 
 
+def test_prefix_owner(pg_db, user_id, prefix):
+    assert pg_db.get_prefix_owner(prefix) == user_id
+
+
+def test_prefix_owner_nonexistent(pg_db):
+    assert pg_db.get_prefix_owner('1234' * 6) is None
+
+
 def test_nonexistent_prefixes(pg_db):
     assert pg_db.get_prefixes(UID) == []
 

--- a/src/blockserver/tests/test_database.py
+++ b/src/blockserver/tests/test_database.py
@@ -1,3 +1,6 @@
+import datetime
+
+import psycopg2
 import pytest
 
 from blockserver.backend.database import AbstractUserDatabase, PostgresUserDatabase
@@ -40,20 +43,20 @@ def test_used_space_inc(pg_db, user_id, prefix):
     size = 500
     second_prefix = pg_db.create_prefix(user_id)
     pg_db.update_size(prefix, size)
-    assert pg_db.get_size(user_id)[1] == size
+    assert pg_db.get_size(user_id) == size
 
     pg_db.update_size(second_prefix, size)
-    assert pg_db.get_size(user_id)[1] == size * 2
+    assert pg_db.get_size(user_id) == size * 2
 
 
 def test_used_space_dec(pg_db, user_id, prefix):
     size = 500
     second_prefix = pg_db.create_prefix(user_id)
     pg_db.update_size(prefix, size)
-    assert pg_db.get_size(user_id)[1] == size
+    assert pg_db.get_size(user_id) == size
 
     pg_db.update_size(second_prefix, -size)
-    assert pg_db.get_size(user_id)[1] == 0
+    assert pg_db.get_size(user_id) == 0
 
 
 def test_traffic_for_prefix(pg_db, user_id, prefix):
@@ -61,28 +64,9 @@ def test_traffic_for_prefix(pg_db, user_id, prefix):
     amount = 500
     pg_db.update_traffic(prefix, amount)
     assert pg_db.get_traffic(user_id) == amount
-
-
-def test_quota(pg_db, user_id):
-    assert pg_db.get_quota(user_id) == 2 * 1024**3
-    pg_db.set_quota(user_id, 10)
-    assert pg_db.get_quota(user_id) == 10
-
-
-def test_set_quota(pg_db, user_id):
-    pg_db.set_quota(user_id, 10)
-    assert pg_db.get_quota(user_id) == 10
-
-
-def test_quota_reached(pg_db, user_id, prefix):
-    size = 10
-    assert not pg_db.quota_reached(user_id, size)
-    pg_db.set_quota(user_id, 10)
-    assert not pg_db.quota_reached(user_id, size - 1)
-    assert pg_db.quota_reached(user_id, size)
-    pg_db.update_size(prefix, 10)
-    assert pg_db.quota_reached(user_id, 0)
-    assert pg_db.quota_reached(user_id, size)
+    different_amount = 123456
+    pg_db.update_traffic(prefix, different_amount)
+    assert pg_db.get_traffic(user_id) == amount + different_amount
 
 
 def test_traffic_by_prefix(pg_db, prefix):
@@ -90,16 +74,43 @@ def test_traffic_by_prefix(pg_db, prefix):
     amount = 500
     pg_db.update_traffic(prefix, amount)
     assert pg_db.get_traffic_by_prefix(prefix) == amount
+    different_amount = 123456
+    pg_db.update_traffic(prefix, different_amount)
+    assert pg_db.get_traffic_by_prefix(prefix) == amount + different_amount
 
 
-def test_quota_reached_by_large_file(pg_db, user_id, prefix):
-    size = 3 * 1024**3
-    assert pg_db.quota_reached(user_id, size)
+def test_traffic_by_prefix_and_month(pg_db, prefix, mocker):
+    def normal_cycle():
+        assert pg_db.get_traffic_by_prefix(prefix) == 0
+        amount = 500
+        pg_db.update_traffic(prefix, amount)
+        assert pg_db.get_traffic_by_prefix(prefix) == amount
+    normal_cycle()
+    this_month = mocker.patch('blockserver.backend.util.this_month')
+    today = datetime.date.today()
+    this_month.return_value = today.replace(day=1, month=today.month + 1)
+    normal_cycle()
+
+
+def test_traffic_by_month(pg_db, prefix, mocker, user_id):
+    def normal_cycle():
+        assert pg_db.get_traffic(user_id) == 0
+        amount = 500
+        pg_db.update_traffic(prefix, amount)
+        assert pg_db.get_traffic(user_id) == amount
+    normal_cycle()
+    this_month = mocker.patch('blockserver.backend.util.this_month')
+    today = datetime.date.today()
+    this_month.return_value = today.replace(day=1, month=today.month + 1)
+    normal_cycle()
+
+
+def test_traffic_integrity(pg_db, prefix, mocker):
+    this_month = mocker.patch('blockserver.backend.util.this_month')
+    this_month.return_value = datetime.date.today().replace(day=2)
+    with pytest.raises(psycopg2.IntegrityError):
+        pg_db.update_traffic(prefix, 123)
 
 
 def test_traffic_default(pg_db):
     assert pg_db.get_traffic_by_prefix("non existing prefix") == 0
-
-
-def test_quota_reached_recursion(pg_db):
-    assert not pg_db.quota_reached(1, 1)

--- a/src/blockserver/tests/test_quota.py
+++ b/src/blockserver/tests/test_quota.py
@@ -22,9 +22,3 @@ def test_quota_reached_meta_upload_granted(quota_policy):
     assert quota_policy.upload(True, 10, False, True)
     assert quota_policy.upload(True, 0, False, True)
     assert not quota_policy.upload(True, 150 * 1024, False, True)
-
-
-def test_traffic_limit(quota_policy, monkeypatch):
-    monkeypatch.setattr(quota_policy, 'TRAFFIC_THRESHOLD', 10)
-    assert quota_policy.download(10)
-    assert not quota_policy.download(11)

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -118,7 +118,8 @@ def test_auth_backend_called(app, cache, http_client, path, auth_path, headers, 
     body = b'Dummy'
     _, prefix, file_name = file_path.split('/')
     auth_server.add_response(services.Request('POST', auth_path),
-                             services.Response(200, body=b'{"user_id": 0, "active":true}'))
+                             services.Response(200, body=b'{"user_id": 0, "active": true,'
+                                                         b'"block_quota": 123, "monthly_traffic_quota": 789}'))
     response = yield http_client.fetch(path, method='POST', body=body, headers=headers,
                                        raise_error=False)
     auth_request = auth_server.get_request(auth_path)
@@ -186,7 +187,8 @@ def test_log_and_monitoring(app, mocker, http_client, path, auth_path, headers,
     size = len(body)
     _, prefix_name, file_name = file_path.split('/')
     auth_server.add_response(services.Request('POST', auth_path),
-                             services.Response(200, body=b'{"user_id": 0, "active":true}'))
+                             services.Response(200, body=b'{"user_id": 0, "active": true,'
+                                                         b'"block_quota": 123, "monthly_traffic_quota": 789}'))
     yield http_client.fetch(path, method='POST', body=body, headers=headers)
     quota = mon_quota({'type': 'increase'})
     assert quota - quota_before == size

--- a/src/blockserver/tests/test_server.py
+++ b/src/blockserver/tests/test_server.py
@@ -22,12 +22,6 @@ def test_dummy_auth_arbitrary_post(backend, http_client, base_url, headers):
 
 
 @pytest.mark.gen_test
-def test_not_found(backend, http_client, path):
-    response = yield http_client.fetch(path, raise_error=False)
-    assert response.code == 404
-
-
-@pytest.mark.gen_test
 def test_no_body(backend, http_client, path, headers, temp_check):
     with temp_check:
         response = yield http_client.fetch(path, method='POST', body=b'', headers=headers,

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -81,7 +81,7 @@ def prefix_path(base_url):
 
 @pytest.fixture
 def auth_path():
-    return '/api/v0/auth/'
+    return '/api/v0/internal/user/'
 
 
 @pytest.fixture

--- a/src/db/versions/262d44e38959_accounting_quota.py
+++ b/src/db/versions/262d44e38959_accounting_quota.py
@@ -1,0 +1,27 @@
+"""
+Remove local (block-server) quota storage, since the quota is now handled by the accounting server.
+
+Revision ID: 262d44e38959
+Revises: 27e9aa8fa794
+Create Date: 2016-05-12 16:37:30.413778
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '262d44e38959'
+down_revision = '27e9aa8fa794'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('users', 'max_quota')
+
+
+def downgrade():
+    op.add_column('users', 'max_quota', type=sa.BIGINT)
+    op.add_column('users', 'max_quota', server_default='2147483648')
+    op.execute('UPDATE users SET max_quota = 2147483648')

--- a/src/db/versions/262d44e38959_accounting_quota.py
+++ b/src/db/versions/262d44e38959_accounting_quota.py
@@ -22,6 +22,6 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column('users', 'max_quota', type=sa.BIGINT)
-    op.add_column('users', 'max_quota', server_default='2147483648')
+    op.add_column('users',
+                  sa.Column('max_quota', sa.BIGINT, default=2147483648))
     op.execute('UPDATE users SET max_quota = 2147483648')

--- a/src/db/versions/27e9aa8fa794_change_quota.py
+++ b/src/db/versions/27e9aa8fa794_change_quota.py
@@ -26,4 +26,4 @@ def upgrade():
 def downgrade():
     op.execute('UPDATE users SET max_quota = 16777216')
     op.alter_column('users', 'max_quota', type_=sa.INTEGER,
-                    server_default=16777216)
+                    server_default='16777216')

--- a/src/db/versions/aa3320db4c7f_traffic_table.py
+++ b/src/db/versions/aa3320db4c7f_traffic_table.py
@@ -33,7 +33,17 @@ def upgrade():
         'traffic_month_constraint', 'traffic',
         "date_trunc('month', traffic_month) = traffic_month",
     )
+    op.execute("INSERT INTO traffic(user_id, traffic, traffic_month) "
+               "SELECT user_id, download_traffic, date_trunc('month', current_date) "
+               "FROM users")
+    op.drop_column('users', 'download_traffic')
 
 
 def downgrade():
+    op.add_column('users',
+                  sa.Column('download_traffic', sa.BIGINT, default=0))
+    op.execute('UPDATE users '
+               'SET download_traffic = traffic.traffic '
+               'FROM traffic '
+               'WHERE traffic.user_id = users.user_id')
     op.drop_table('traffic')

--- a/src/db/versions/aa3320db4c7f_traffic_table.py
+++ b/src/db/versions/aa3320db4c7f_traffic_table.py
@@ -1,0 +1,39 @@
+"""
+Create a traffic table for storing monthly traffic.
+
+Revision ID: aa3320db4c7f
+Revises: 262d44e38959
+Create Date: 2016-05-13 10:37:08.185975
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'aa3320db4c7f'
+down_revision = '262d44e38959'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'traffic',
+        sa.Column('user_id', sa.INTEGER),
+        sa.Column('traffic_month', sa.DATE),
+        sa.Column('traffic', sa.BIGINT, default=0),
+    )
+    op.create_primary_key(
+        'pk_traffic', 'traffic',
+        ['user_id', 'traffic_month']
+    )
+    op.create_check_constraint(
+        # ensure that only months are stored, not days
+        'traffic_month_constraint', 'traffic',
+        "date_trunc('month', traffic_month) = traffic_month",
+    )
+
+
+def downgrade():
+    op.drop_table('traffic')


### PR DESCRIPTION
Implements #31 

Partial implementation of #30, which will need another accounting API. The traffic log is stored monthly now (currently old months won't be deleted automatically, since they might be useful for analysis / fancy graphs), but the get quota stuff is still static (QuotaPolicy).

So this is "semi WIP".

* This uses Upserts for atomic insert-or-update semantics; pgsql 9.5 would be required at the moment.
* Old redis caches are invalid
* When upgrading the DB the current download_traffic is migrated into the current month (downgrade vice-versa)
* Needs accounting>=753e91d
* Not yet tested in a live environment in conjunction with the accounting server
* Needs pgsql 9.5; document requirement. 9.4->9.5 bump is ok, both AWS RDS (9.5.2) and ubuntu 16.04 have it.