### PR TITLE
Implement If-Match ETag checking for POST requests

### DIFF
--- a/src/blockserver/monitoring.py
+++ b/src/blockserver/monitoring.py
@@ -14,6 +14,8 @@ TIME_IN_TRANSFER_STORE = Histogram('block_wait_for_transfer_store',
                                    'Time spent storing a file')
 TIME_IN_TRANSFER_RETRIEVE = Histogram('block_wait_for_transfer_retrieve',
                                       'Time spent retrieving a file')
+TIME_IN_TRANSFER_META = Histogram('block_wait_for_transfer_meta',
+                                  'Time spent retrieving meta-data (HEAD) of a file')
 TIME_IN_TRANSFER_DELETE = Histogram('block_wait_for_transfer_delete',
                                     'Time spent deleting a file')
 

--- a/src/blockserver/tests/test_transfer.py
+++ b/src/blockserver/tests/test_transfer.py
@@ -60,3 +60,22 @@ def test_get_size_does_not_corrupt_cache(cache, transfer, testfile):
     transfer.store(storage_object)
     cache.flush()
     transfer.get_size(StorageObject('foo', 'baz'))
+
+
+def test_meta(testfile, cache, transfer):
+    size = os.path.getsize(testfile)
+    named_object = StorageObject('fus-roh', 'bar')
+    transfer.delete(named_object)  # XXX tests should clean up
+    storage_object = named_object._replace(local_file=testfile)
+    assert transfer.meta(named_object) is None
+
+    uploaded, _ = transfer.store(storage_object)
+
+    meta = transfer.meta(named_object)
+    assert meta.size == size
+    assert meta.size == uploaded.size
+    assert meta.etag == uploaded.etag
+
+
+def test_meta_non_existing_file(cache, transfer):
+    assert transfer.meta(StorageObject('making-things', 'up')) is None


### PR DESCRIPTION
If the client supplies an If-Match header then the supplied ETag
must match the currently stored object, otherwise the request is aborted
with HTTP 412 (precondition failed). This allows proper, safe overwriting
semantics by avoiding lost updates.

Fixes #44

TODO: docs repo spec update
TODO: AbstractTransfer.meta() should replace AbstractTransfer.get_size() entirely.