### PR TITLE
pytest-dbfixtures -> pytest-postgresql

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 hiredis==0.2.0
 glinda==0.0.3
 boto3==1.2.3
-pytest==2.8.7
+pytest==3.0.5
 tornado==4.3
 redis==2.10.5
 pytest-tornado==0.4.4
@@ -9,7 +9,7 @@ prometheus_client==0.0.13
 wrapt==1.10.6
 asyncio==3.4.3
 psycopg2==2.6.1
-pytest-dbfixtures==0.13.1
+pytest-postgresql==1.1.1
 pytest-mock==0.11.0
 alembic==0.8.5
 invoke==0.13.0

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -8,12 +8,12 @@ import tempfile
 import traceback
 from tempfile import NamedTemporaryFile
 
+import psycopg2
 import tornado
 from alembic.command import upgrade
 from alembic.config import Config
 from glinda.testing import services
-from pytest_dbfixtures.factories.postgresql import init_postgresql_database
-from pytest_dbfixtures.utils import try_import
+from pytest_postgresql.factories import get_config, init_postgresql_database
 from tornado.options import options
 
 import blockserver.backend.cache as cache_backends
@@ -153,14 +153,15 @@ def apply_migrations(user, host, port, db):
 
 @pytest.fixture(scope='session')
 def pg_connection(request, postgresql_proc):
-    psycopg2, config = try_import('psycopg2', request)
+    config = get_config(request)
+    pg_user = config['user']
     pg_host = postgresql_proc.host
     pg_port = postgresql_proc.port
-    pg_db = config.postgresql.db
+    pg_db = config['db'] = 'tests'
 
-    init_postgresql_database(psycopg2, config.postgresql.user, pg_host, pg_port, pg_db)
-    apply_migrations(config.postgresql.user, pg_host, pg_port, pg_db)
-    conn = psycopg2.connect(dbname=pg_db, user=config.postgresql.user,
+    init_postgresql_database(pg_user, pg_host, pg_port, pg_db)
+    apply_migrations(pg_user, pg_host, pg_port, pg_db)
+    conn = psycopg2.connect(dbname=pg_db, user=pg_user,
                             host=pg_host, port=pg_port)
     return conn
 


### PR DESCRIPTION
due to an underspecified dependency and use of deprecated features
(in the path.py library) building the project with a fresh checkout
failed since 2017-01-01.